### PR TITLE
Users can sign in using the sign in endpoint

### DIFF
--- a/server/controller/Auth.js
+++ b/server/controller/Auth.js
@@ -43,6 +43,48 @@ class AuthController {
     return jsonResponse.success(res, 'success', 201, data);
   }
 
+  /**
+   * Login a user
+   * @param  {object} req - Request object
+   * @param {object} res - Response object
+   * @return {json} res.json
+   */
+  static async signin(req, res) {
+    const { email, password } = req.body;
+
+    const findUser = await pool.query(queryHelper.findUserByEmail, [email.toLowerCase()]);
+
+    if (findUser.rowCount < 1) {
+      return jsonResponse.error(res, 'error', 404, 'User does not exist');
+    }
+
+    const verify = await AuthController.verifyPassword(password, findUser.rows[0].password);
+
+    if (verify === true) {
+      const token = await Authorization.generateToken(findUser.rows[0]);
+
+      const data = {
+        token,
+        ...findUser.rows[0],
+      };
+
+      return jsonResponse.success(res, 'success', 200, data);
+    }
+
+    return jsonResponse.error(res, 'error', 401, 'Email or password incorrect');
+  }
+
+  /**
+   * @method verifyPassword
+   * @memberof Users
+   * @param {string} password
+   * @param {string} hash
+   * @return {Promise} Promise of true or false
+   */
+  static verifyPassword(password, hash) {
+    return bcrypt.compare(password, hash);
+  }
+
   static async findUserByEmail(email) {
     const findUser = await pool.query(queryHelper.findUserByEmail, [email.toLowerCase()]);
 

--- a/server/routes/Auth.js
+++ b/server/routes/Auth.js
@@ -5,5 +5,6 @@ import AuthValidations from '../validations/auth';
 const router = express.Router();
 
 router.post('/signup', AuthValidations.signup, auth.signup);
+router.post('/signin', AuthValidations.signin, auth.signin);
 
 export default router;

--- a/server/utils/joi.js
+++ b/server/utils/joi.js
@@ -7,8 +7,18 @@ const signupSchema = Joi.object().keys({
     .required(),
   password: Joi.string().regex(/^[a-zA-Z0-9$@$!%*?&]{3,30}$/).required(),
   email: Joi.string().email({ minDomainSegments: 2 }).required(),
-  is_admin: Joi.boolean()
+  is_admin: Joi.boolean(),
+  dob: Joi.string(),
+  street: Joi.string(),
+  city: Joi.string(),
+  state: Joi.string(),
+  country: Joi.string(),
+});
+
+const signinSchema = Joi.object().keys({
+  password: Joi.string().regex(/^[a-zA-Z0-9$@$!%*?&]{3,30}$/).required(),
+  email: Joi.string().email({ minDomainSegments: 2 }).required(),
 });
 
 
-export { signupSchema };
+export { signupSchema, signinSchema };

--- a/server/validations/auth.js
+++ b/server/validations/auth.js
@@ -1,5 +1,5 @@
 import Joi from '@hapi/joi';
-import { signupSchema } from '../utils/joi';
+import { signupSchema, signinSchema } from '../utils/joi';
 import JSONResponse from '../helper/responseHandler';
 
 
@@ -11,11 +11,19 @@ class AuthValidations {
     const valid = error == null;
 
     if (!valid) {
-      // res.status(422).json({
-      // message: 'Invalid request',
-      // data: body
-      // })
+      return JSONResponse.error(res, 'error', 422, error.details[0].message);
+    }
 
+    return next();
+  }
+
+  static signin(req, res, next) {
+    const data = req.body;
+    const { error } = Joi.validate(data, signinSchema);
+
+    const valid = error == null;
+
+    if (!valid) {
       return JSONResponse.error(res, 'error', 422, error.details[0].message);
     }
 

--- a/test/auth.js
+++ b/test/auth.js
@@ -71,4 +71,81 @@ describe('Users Authentication', () => {
             })
         });
     });
+
+    describe('POST /api/v1/auth/signin', () => {
+        it('should log in a user',  (done) => {
+            chai.request(app)
+            .post('/api/v1/auth/signin')
+            .send({
+                email: "non@test.co",
+                password: "Password1!"
+            })
+            .then((res) => {
+                const body = res.body;
+                expect(res.status).to.equal(200);
+                expect(body).to.contain.property('status');
+                expect(body).to.contain.property('data');
+                expect(body.data).to.contain.property('token');
+                expect(body.status).to.equal("success");
+                expect(body.data).to.be.an("object");
+                done()
+            })
+        });
+
+        it('should check if user does not exists', (done) => {
+            chai.request(app)
+            .post('/api/v1/auth/signin')
+            .send({
+                email: "tes@test.co",
+                password: "Password1!"
+            })
+            .then((res) => {
+                const body = res.body;
+                expect(res.status).to.equal(404);
+                expect(body).to.contain.property('status');
+                expect(body).to.contain.property('error');
+                expect(body.status).to.equal("error");
+                expect(body.error).to.be.a("string");
+                expect(body.error).to.equal("User does not exist");
+                done()
+            })
+        });
+
+        it('should for wrong email-password combination', (done) => {
+            chai.request(app)
+            .post('/api/v1/auth/signin')
+            .send({
+                email: "non@test.co",
+                password: "Password1!r"
+            })
+            .then((res) => {
+                const body = res.body;
+                expect(res.status).to.equal(401);
+                expect(body).to.contain.property('status');
+                expect(body).to.contain.property('error');
+                expect(body.status).to.equal("error");
+                expect(body.error).to.be.a("string");
+                expect(body.error).to.equal("Email or password incorrect");
+                done()
+            })
+        });
+
+        it('should for return error for incomplete body request', (done) => {
+            chai.request(app)
+            .post('/api/v1/auth/signin')
+            .send({
+                email: "non@test.co"
+            })
+            .then((res) => {
+                const body = res.body;
+                expect(res.status).to.equal(422);
+                expect(body).to.contain.property('status');
+                expect(body).to.contain.property('error');
+                expect(body.status).to.equal("error");
+                expect(body.error).to.be.a("string");
+                expect(body.error).to.equal('"password\" is required');
+                done()
+            })
+        });
+    });
 })


### PR DESCRIPTION
#### What does this PR do?
Add the controller and route for user sign in authentication
#### Description of Task to be completed?
Have the following endpoint working
POST /api/v1/auth/signup
POST /api/v1/auth/signin
#### How should this be manually tested?
After cloning the repo, cd into it, set the environment variables and run `npm run start:dev`
* Using postman, test for the above enpoint
* The body of the request for sign up should contain at least `first_name` `last_name` `email` `password`
* The body request for sign in should contain the `email` and `password`
#### What are the relevant pivotal tracker stories?
#167689380
